### PR TITLE
feat(workflows): add a shared publish-please workflow

### DIFF
--- a/.github/workflows/publish-please.yml
+++ b/.github/workflows/publish-please.yml
@@ -1,0 +1,49 @@
+name: Publish Please
+
+on:
+    workflow_call:
+        inputs:
+            github_ref:
+                description: The git ref to publish
+                type: string
+                required: true
+        secrets:
+            READONLY_NPM_TOKEN:
+                description: Needed to install private @hedia npm packages
+                required: true
+            PUBLISHING_NPM_TOKEN:
+                description: Needed to publish @hedia npm packages
+                required: true
+
+jobs:
+  publish-please:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+        - name: Checkout Repository
+          uses: actions/checkout@v3
+          with:
+              ref: ${{ inputs.github_ref }}
+              fetch-depth: 1
+
+        - name: Setup Node.js Environment
+          uses: actions/setup-node@v3
+          with:
+              node-version-file: "package.json"
+              always-auth: true
+              registry-url: https://registry.npmjs.org
+              scope: "@hedia"
+
+        - name: Install Dependencies
+          run: npm ci
+          env:
+              NODE_AUTH_TOKEN: ${{ secrets.READONLY_NPM_TOKEN }}
+
+        - name: Build
+          run: npm run build --if-present
+
+        - name: Publish to npm
+          run: npm publish
+          env:
+              NODE_AUTH_TOKEN: ${{ secrets.PUBLISHING_NPM_TOKEN }}


### PR DESCRIPTION
this is to be called by other workflows.

they must pass a `github_ref` (i.e. `"refs/tags/v2.0.0"`) so that we know where to check out for publishing.

the secrets `READONLY_NPM_TOKEN` and `PUBLISHING_NPM_TOKEN` are already available as organization secrets and will come along with `secrets: inherit`