### PR TITLE
refactor(workflows): separate release and publish into two different shared workflows

### DIFF
--- a/.github/workflows/publish-please.yml
+++ b/.github/workflows/publish-please.yml
@@ -1,0 +1,49 @@
+name: Publish Please
+
+on:
+    workflow_call:
+        inputs:
+            github_ref:
+                description: The git ref to publish
+                type: string
+                required: true
+        secrets:
+            READONLY_NPM_TOKEN:
+                description: Needed to install private @hedia npm packages
+                required: true
+            PUBLISHING_NPM_TOKEN:
+                description: Needed to publish @hedia npm packages
+                required: true
+
+jobs:
+    publish-please:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+
+        steps:
+            - name: Checkout Repository
+              uses: actions/checkout@v3
+              with:
+                  ref: ${{ inputs.github_ref }}
+                  fetch-depth: 1
+
+            - name: Setup Node.js Environment
+              uses: actions/setup-node@v3
+              with:
+                  node-version-file: "package.json"
+                  always-auth: true
+                  registry-url: https://registry.npmjs.org
+                  scope: "@hedia"
+
+            - name: Install Dependencies
+              run: npm ci
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.READONLY_NPM_TOKEN }}
+
+            - name: Build
+              run: npm run build --if-present
+
+            - name: Publish to npm
+              run: npm publish
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.PUBLISHING_NPM_TOKEN }}

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -2,13 +2,6 @@ name: Release and Publish
 
 on:
     workflow_call:
-        secrets:
-            READONLY_NPM_TOKEN:
-                description: Needed to install private @hedia npm packages
-                required: true
-            PUBLISHING_NPM_TOKEN:
-                description: Needed to publish @hedia npm packages
-                required: true
 
 permissions:
     contents: write
@@ -17,46 +10,13 @@ permissions:
 jobs:
     release-and-publish:
         runs-on: ubuntu-latest
-        if: >
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'pull_request' &&
-              github.event.pull_request.merged == true &&
-              contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
-            )
         steps:
-            - uses: google-github-actions/release-please-action@v3
+            - name: Release Please
+              uses: hedia-team/.github/.github/workflows/release-please.yml@latest
               id: release
+
+            - name: Publish Please
+              if: steps.release.outputs.release_created == 'true'
+              uses: hedia-team/.github/.github/workflows/publish-please.yml@latest
               with:
-                  release-type: node
-
-            - if: steps.release.outputs.release_created == 'true'
-              name: Checkout Repository
-              uses: actions/checkout@v3
-              with:
-                  ref: ${{ github.ref }}
-                  fetch-depth: 1
-
-            - if: steps.release.outputs.release_created == 'true'
-              name: Setup Node.js Environment
-              uses: actions/setup-node@v3
-              with:
-                  node-version-file: "package.json"
-                  always-auth: true
-                  registry-url: https://registry.npmjs.org
-                  scope: "@hedia"
-
-            - if: steps.release.outputs.release_created == 'true'
-              name: Install Dependencies
-              run: npm ci
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.READONLY_NPM_TOKEN }}
-
-            - if: steps.release.outputs.release_created == 'true'
-              name: Build
-              run: npm run build --if-present
-
-            - if: steps.release.outputs.release_created == 'true'
-              name: Publish to npm
-              run: npm publish
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.PUBLISHING_NPM_TOKEN }}
+                  github_ref: ${{ github.ref }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,22 @@
+name: Release Please
+
+on:
+    workflow_call:
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    release-please:
+        runs-on: ubuntu-latest
+        if: >
+            github.event_name == 'workflow_dispatch' ||
+            (github.event_name == 'pull_request' &&
+              github.event.pull_request.merged == true &&
+              contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+            )
+        steps:
+            - uses: google-github-actions/release-please-action@v3
+              with:
+                  release-type: node


### PR DESCRIPTION
this actually brings back the ones i had before, and references both of them from the release-and-publish workflow.

easier sharing and better readability, yay!