### PR TITLE
feat(workflows): Ensure that PR titles conform to the conventional commits spec

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,20 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -12,8 +12,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  main:
-    name: title follows Conventional Commits spec
+  title:
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,7 +1,7 @@
 name: PR
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,4 +1,4 @@
-name: PR
+name: Pull Request
 
 on:
   pull_request:

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -15,7 +15,7 @@ jobs:
   title:
     runs-on: ubuntu-latest
     steps:
-      - name: Title follows Conventional Commits spec
+      - name: Check that title follows Conventional Commits spec
         uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - synchronize
+  workflow_call:
 
 permissions:
   pull-requests: read

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,4 +1,4 @@
-name: "Lint PR"
+name: PR
 
 on:
   pull_request_target:
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   main:
-    name: Validate PR title
+    name: title follows Conventional Commits spec
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -15,6 +15,7 @@ jobs:
   title:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - name: Title follows Conventional Commits spec
+        uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Note that we probably want to [default to PR titles for squash merge commit messages](https://github.blog/changelog/2022-05-11-default-to-pr-titles-for-squash-merge-commit-messages/) on repositories that use this.

![Screenshot 2024-06-03 at 10 47 51](https://github.com/hedia-team/.github/assets/1035167/b06e926e-8dbd-4822-b396-a9f58d6a60c3)
