### PR TITLE
fix(update-please): remove backend as a target topic option for Update Please

### DIFF
--- a/.github/workflows/update-please.yml
+++ b/.github/workflows/update-please.yml
@@ -22,10 +22,9 @@ on:
                 type: choice
                 description: Target repositories with topic
                 required: true
-                default: backend
+                default: service
                 options:
                     - app
-                    - backend
                     - dev
                     - io
                     - module


### PR DESCRIPTION
.github is itself a backend repo, so this causes an infinite loop.

i think it's safer not to be able to run on everything, anyway.