### PR TITLE
feat: use lcov for Sonarcloud instead of coverage.xml

### DIFF
--- a/.github/workflows/ci-sonarcloud.yml
+++ b/.github/workflows/ci-sonarcloud.yml
@@ -43,7 +43,7 @@ jobs:
 
             - name: Check Coverage
               id: coverage
-              run: test -e coverage/coverage.xml && echo "file=true" >> $GITHUB_OUTPUT || echo "file=false" >> $GITHUB_OUTPUT
+              run: test -e coverage/lcov.info && echo "file=true" >> $GITHUB_OUTPUT || echo "file=false" >> $GITHUB_OUTPUT
 
             - name: Select Project
               env:
@@ -59,4 +59,4 @@ jobs:
                   args: >
                       -Dsonar.projectKey=${{ env.GITHUB_PROJECT }}
                       -Dsonar.organization=${{ github.repository_owner }}
-                      ${{steps.coverage.outputs.file == 'true' && '-Dsonar.coverageReportPaths=coverage/coverage.xml' || ''}}
+                      ${{steps.coverage.outputs.file == 'true' && '-Dsonar.javascript.lcov.reportPaths=coverage/lcov.info' || ''}}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -111,4 +111,4 @@ jobs:
               uses: actions/upload-artifact@v4
               with:
                   name: coverage
-                  path: coverage.xml
+                  path: lcov.info


### PR DESCRIPTION
i think we should release this and make it `latest`.

projects that don't yet have the lcov.info won't fail, they just won't send any coverage request to sonarcloud.

given the coverage.xml is currently not working anyway, this is no worse than the current situation.