### PR TITLE
feat: Enable bulk Approve Please for the mobile team

### DIFF
--- a/.github/workflows/bulk-approve-please.yml
+++ b/.github/workflows/bulk-approve-please.yml
@@ -18,6 +18,7 @@ on:
                     - backend
                     - bots
                     - development
+                    - mobile
             label:
                 type: choice
                 description: PR must have label


### PR DESCRIPTION
Now that we have a separate mobile team configured in GitHub, it makes sense to enable it here.