### PR TITLE
feat: Initiate E2E tests automatically as soon as a Docker image has been built

### DIFF
--- a/.github/workflows/dockerize-please.yml
+++ b/.github/workflows/dockerize-please.yml
@@ -61,3 +61,9 @@ jobs:
                   tags: |
                       ghcr.io/${{ github.repository }}:${{ inputs.tag_name }}
                       ghcr.io/${{ github.repository }}:latest
+
+            - name: Initiate E2E test workflow
+              run: |
+                  gh workflow run --repo hedia-team/e2e-service --raw-field suite="All" test-please.yml
+              env:
+                  GH_TOKEN: ${{ secrets.HEDIA_BOT_GITHUB_PAT }}


### PR DESCRIPTION
If it works, this will really streamline the whole release - build - test workflow, removing another manual step.

Closes #104