### PR TITLE
ci: Remove the scheduled bulk update please

### DIFF
--- a/.github/workflows/bulk-update-please.yml
+++ b/.github/workflows/bulk-update-please.yml
@@ -1,9 +1,6 @@
 name: Bulk Update Please
 
 on:
-    schedule:
-        - cron: "0 1 * * 1"
-
     workflow_dispatch:
         inputs:
             topic:


### PR DESCRIPTION
When all the repos had their own schedule, it worked ok because GitHub doesn't guarantee it'll happen at exactly that time. So, at some number of minutes past 1am, each repo would wake up and do its thing.

Recently we switched so that, at some minutes past 1am, this job would wake up, and suddenly make ALL OF THE REPOS do the thing ALL AT ONCE!

This causes lots of PRs to get made, and at some point GitHub gets annoyed and applies a rate limit. The branches hang around, but no PR gets created, which leaves dangling branches.

So we discussed, and decided maybe we don't need this scheduled dependency updating anymore, since we can just wait for monthly alignment.

Of course, we can still run bulk update please when we know there's something specific we want updated. This just removes the scheduled trigger.