### PR TITLE
fix: Update the release check to be more permissive

### DIFF
--- a/.github/actions/set-labels/action.yml
+++ b/.github/actions/set-labels/action.yml
@@ -16,6 +16,7 @@ runs:
               script: |
                   const { NUMBER, OWNER, REPO, TITLE } = process.env
                   const regex = /^(build|chore|ci|deps|docs|feat|fix|perf|refactor|revert|style|test)(?:\((\S+)\))?(!)?: (.+)$/;
+                  const releaseRegex = /^chore\(\S*\): release/;
 
                   console.log(`Checking title "${TITLE}"`);
                   console.log("For more information: https://www.conventionalcommits.org/en/v1.0.0/");
@@ -49,7 +50,7 @@ runs:
                       labels.push("patch");
                   }
 
-                  if (TITLE.startsWith("chore(main): release")) {
+                  if (releaseRegex.test(TITLE)) {
                       labels.push("autorelease: pending");
                   }
 


### PR DESCRIPTION
This should enable us to release Hedia Server from a release candidate.

Proof that it will work:

<img width="418" alt="Screenshot 2024-12-03 at 12 17 35" src="https://github.com/user-attachments/assets/9841fc05-d7e7-4f25-9c00-d71e2242528e">
