### PR TITLE
feat: Enable passing a specific version number to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,10 @@ on:
                 required: false
                 default: false
                 type: boolean
+            version:
+                description: Specific version number to release, eg '3.0.0' or '3.1.0-rc.0'. If not provided, release-please will determine the version.
+                required: false
+                type: string
 
         outputs:
             release_created:
@@ -60,6 +64,7 @@ jobs:
                   token: ${{ secrets.HEDIA_BOT_GITHUB_PAT }}
                   default-branch: ${{ github.ref_name }}
                   changelog-types: '[{"type":"feat","section":"New Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"revert","section":"Reverted Changes","hidden":false},{"type":"perf","section":"Performance Improvements","hidden":false},{"type":"refactor","section":"Code Refactoring","hidden":false},{"type":"build","section":"Build Process","hidden":false},{"type":"ci","section":"CI/CD","hidden":false},{"type":"test","section":"Testing","hidden":false},{"type":"chore","section":"Chores","hidden":false},{"type":"docs","section":"Documentation Updates","hidden":false},{"type":"style","section":"Code Formatting","hidden":false}]'
+                  release-as: ${{ inputs.version || '' }}
 
         outputs:
             release_created: ${{ steps.release-please.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,7 +23,7 @@ on:
                 default: false
                 type: boolean
             version:
-                description: Specific version number to release, eg '3.0.0' or '3.1.0-rc.0'. If not provided, release-please will determine the version.
+                description: Specific version number to release, eg '3.0.0' or '3.1.0-rc.0'. If not provided, Release Please will determine the version.
                 required: false
                 type: string
 


### PR DESCRIPTION
This will save me so much time going and editing PRs to get the desired version number.

If not specified, Release Please will determine the next version like it always does.

Examples of me using it: https://github.com/hedia-team/hedia-server/pull/500