### PR TITLE
feat: Use latest sonarqube action

### DIFF
--- a/.github/workflows/ci-sonarcloud.yml
+++ b/.github/workflows/ci-sonarcloud.yml
@@ -51,7 +51,7 @@ jobs:
               run: echo "GITHUB_PROJECT=${GITHUB_PROJECT/\//_}" >> $GITHUB_ENV
 
             - name: SonarCloud Scan
-              uses: SonarSource/sonarcloud-github-action@v2
+              uses: SonarSource/sonarqube-scan-action@v5
               env:
                   GITHUB_TOKEN: ${{ github.token }}
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Replaced [SonarCloud](https://github.com/SonarSource/sonarcloud-github-action) (deprecated) by [SonarQube](https://github.com/SonarSource/sonarqube-scan-action) action. It takes the same time though...